### PR TITLE
Lazy fix to suppress wasted filetype unsupported for webms

### DIFF
--- a/app/wasted.go
+++ b/app/wasted.go
@@ -62,7 +62,7 @@ var wastedCommand = BotCommand{
 			return
 		}
 
-		if len(path) <= 4 || path[len(path)-4:] != ".mp4" {
+		if len(path) <= 4 || !(path[len(path)-4:] == ".mp4" || path[len(path)-5:] == ".webm" ) {
 			respChan <- *NewTextBotResponse(fmt.Sprintf("Unsupported filetype: %s", path), update.Message.Chat.ID)
 		}
 


### PR DESCRIPTION
### Notes
DanDan posted webms and wasted worked fine, but the error message shows up anyway. Just suppressing it.

### Testing
it builds and runs

Signed-off-by: Jacob Mason <jacob@jacobmason.net>